### PR TITLE
[Feature/playbooks/minio.ops] - Advance logics for seperating backup task for root and nonroot user

### DIFF
--- a/playbooks/roles/minio.ops/backup.ops/tasks/backup.yml
+++ b/playbooks/roles/minio.ops/backup.ops/tasks/backup.yml
@@ -1,9 +1,20 @@
 ---
 - name: Backup data to minio bucket
   command: "/home/{{ ansible_user }}/backup.sh"
-  register: result
+  register: nonroot_result
+  when: ansible_user != "root"
+
+- name: Backup data to minio bucket (root)
+  command: "/root/backup.sh"
+  register: root_result
+  when: ansible_user == "root"
 
 - name: Check if backup job has completed successfully
   ansible.builtin.debug:
     msg: "Backup ran successfully!"
-  when: result.rc == 0
+  when: nonroot_result is changed
+
+- name: Check if backup job (root) has completed successfully
+  ansible.builtin.debug:
+    msg: "Backup ran successfully!"
+  when: root_result is changed

--- a/playbooks/roles/minio.ops/setup.ops/tasks/authenticate.yml
+++ b/playbooks/roles/minio.ops/setup.ops/tasks/authenticate.yml
@@ -14,21 +14,10 @@
   ansible.builtin.set_fact:
     current_server={{ server.stdout }}
 
-- name: Update minio server ip
-  shell: |
-    mv ~/.mc/config.json ~/.mc/config.json.backup
-    jq '.aliases.minio.url |= "{{ remote_server }}"' ~/.mc/config.json.backup | tee -a ~/.mc/config.json > /dev/null
-  register: is_server_changed
-  when: remote_server != current_server
-
-- name: Report result
-  ansible.builtin.debug:
-    msg: "Successfully updated minio server connection! Current minio server: {{ remote_server }}"
-  when: is_server_changed is changed
-
 - name: Verify configurations
   command: "mc ls minio"
   register: config_verified
+
 
 - name: Connect to remote minio server with credentials
   command: "mc config host add minio {{ remote_server }} {{ lookup('env','MINIO_ACCESS_KEY') }} {{ lookup('env','MINIO_SECRET_KEY') }}"
@@ -47,3 +36,16 @@
   when: 
     - config_verified.stdout | length == 0
     - authentication_result.rc == 0
+
+- name: Update minio server ip
+  shell: |
+    mv ~/.mc/config.json ~/.mc/config.json.backup
+    jq '.aliases.minio.url |= "{{ remote_server }}"' ~/.mc/config.json.backup | tee -a ~/.mc/config.json > /dev/null
+  register: is_server_changed
+  when: remote_server != current_server
+
+- name: Report result
+  ansible.builtin.debug:
+    msg: "Successfully updated minio server connection! Current minio server: {{ remote_server }}"
+  when: is_server_changed is changed
+


### PR DESCRIPTION
- fix: updated task order
- fix: seperate root user and nonroot user for backup task
