### PR TITLE
[Feature/playbooks/apt.ops] - Seperate dist upgrade from regular apt upgrade

### DIFF
--- a/ansible-playbooks/playbooks/apt/update-apt-packages.yml
+++ b/ansible-playbooks/playbooks/apt/update-apt-packages.yml
@@ -5,3 +5,5 @@
 
   roles:
     - role: ../../roles/apt.ops/update.ops/
+      vars:
+        - dist_upgrade: false # set this var to true will perform dist upgrade

--- a/ansible-playbooks/roles/apt.ops/update.ops/tasks/apt-upgrade.yml
+++ b/ansible-playbooks/roles/apt.ops/update.ops/tasks/apt-upgrade.yml
@@ -3,7 +3,3 @@
   ansible.builtin.apt:
     update_cache: yes
     upgrade: yes
-
-- name: Upgrade the OS (apt-get dist-upgrade)
-  ansible.builtin.apt:
-    upgrade: dist

--- a/ansible-playbooks/roles/apt.ops/update.ops/tasks/dist-apt-upgrade.yml
+++ b/ansible-playbooks/roles/apt.ops/update.ops/tasks/dist-apt-upgrade.yml
@@ -1,0 +1,5 @@
+---
+- name: Upgrade the OS (apt-get dist-upgrade)
+  ansible.builtin.apt:
+    update_cache: yes
+    upgrade: dist

--- a/ansible-playbooks/roles/apt.ops/update.ops/tasks/main.yml
+++ b/ansible-playbooks/roles/apt.ops/update.ops/tasks/main.yml
@@ -1,1 +1,7 @@
-- include_tasks: apt-update.yml
+---
+# dist upgrade
+- include_tasks: apt-upgrade.yml
+  when: not dist_upgrade
+# normal upgrade
+- include_tasks: disk-apt-upgrade.yml
+  when: dist_upgrade


### PR DESCRIPTION
- fix: seperate dist upgrade from normal upgrade
- feat(apt.ops): added dist_upgrade vars to better control the upgrade ops
