### PR TITLE
Revert "[Patch/terraform-modules/lxc-unprivileged-container] Enable fuse by default"

### DIFF
--- a/terraform-modules/proxmox-ve/lxc-unprivileged/resources.tf
+++ b/terraform-modules/proxmox-ve/lxc-unprivileged/resources.tf
@@ -17,7 +17,6 @@ resource "proxmox_lxc" "container" {
   features {
     keyctl  = true
     nesting = true
-    fuse    = true
   }
 
   rootfs {


### PR DESCRIPTION
Reverts techprober/cloud-estate#232